### PR TITLE
fix(deps): require proto-plus 1.15.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
         # Until this issue is closed
         # https://github.com/googleapis/google-cloud-python/issues/10566
         "google-api-core[grpc] >= 1.26.0, <3.0.0dev",
-        "proto-plus >= 1.4.0",
+        "proto-plus >= 1.15.0",
         "packaging >= 14.3",
     ),
     python_requires=">=3.6",

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -20,6 +20,6 @@
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
 google-api-core==1.26.0
-proto-plus==1.4.0
+proto-plus==1.15.0
 packaging==14.3
 google-auth==1.24.0  # TODO: remove when google-auth>=1.25.0 is required through google-api-core


### PR DESCRIPTION
I'd like to bump the dependency `proto-plus` to 1.15.0 before the client library goes GA for consistency with other googleapis python repositories.