### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "domains",
     "name_pretty": "Cloud Domains",
     "product_documentation": "https://cloud.google.com/domains",
-    "client_documentation": "https://googleapis.dev/python/domains/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/domains/latest",
     "issue_tracker": "",
     "release_level": "beta",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.