### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-### [1.1.2](https://github.com/googleapis/python-domains/compare/v1.1.1...v1.1.2) (2022-05-05)
+## [1.1.2](https://github.com/googleapis/python-domains/compare/v1.1.1...v1.1.2) (2022-05-05)
 
 
 ### Documentation
 
 * fix type in docstring for map fields ([b12a2cd](https://github.com/googleapis/python-domains/commit/b12a2cdfb0906232f035bafbabedfecb0d24a815))
 
-### [1.1.1](https://github.com/googleapis/python-domains/compare/v1.1.0...v1.1.1) (2022-03-05)
+## [1.1.1](https://github.com/googleapis/python-domains/compare/v1.1.0...v1.1.1) (2022-03-05)
 
 
 ### Bug Fixes
@@ -33,7 +33,7 @@
 
 * bump release level to production/stable ([#82](https://www.github.com/googleapis/python-domains/issues/82)) ([24606e7](https://www.github.com/googleapis/python-domains/commit/24606e7dd3a90509e702d25edea9b0256420e3ae))
 
-### [0.4.1](https://www.github.com/googleapis/python-domains/compare/v0.4.0...v0.4.1) (2021-11-01)
+## [0.4.1](https://www.github.com/googleapis/python-domains/compare/v0.4.0...v0.4.1) (2021-11-01)
 
 
 ### Bug Fixes
@@ -67,21 +67,21 @@
 
 * add context manager support in client ([#71](https://www.github.com/googleapis/python-domains/issues/71)) ([9b49d70](https://www.github.com/googleapis/python-domains/commit/9b49d7047d5a71899670d87dd522f8a83566e627))
 
-### [0.2.3](https://www.github.com/googleapis/python-domains/compare/v0.2.2...v0.2.3) (2021-09-30)
+## [0.2.3](https://www.github.com/googleapis/python-domains/compare/v0.2.2...v0.2.3) (2021-09-30)
 
 
 ### Bug Fixes
 
 * improper types in pagers generation ([17d4bed](https://www.github.com/googleapis/python-domains/commit/17d4bed929328cfad16595e0c27d8cf67456f633))
 
-### [0.2.2](https://www.github.com/googleapis/python-domains/compare/v0.2.1...v0.2.2) (2021-09-24)
+## [0.2.2](https://www.github.com/googleapis/python-domains/compare/v0.2.1...v0.2.2) (2021-09-24)
 
 
 ### Bug Fixes
 
 * add 'dict' annotation type to 'request' ([fa12c9b](https://www.github.com/googleapis/python-domains/commit/fa12c9b4f77bf43a41df5bb84e3a12c7c2b5a48f))
 
-### [0.2.1](https://www.github.com/googleapis/python-domains/compare/v0.2.0...v0.2.1) (2021-07-28)
+## [0.2.1](https://www.github.com/googleapis/python-domains/compare/v0.2.0...v0.2.1) (2021-07-28)
 
 
 ### Bug Fixes


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed. Towards b/231248807.